### PR TITLE
makefile: Support DESTDIR, rc.init: Fix redirections and white-space, Plus other fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ build: src/init.c
 	$(CC) src/signals.c src/init.c -o hummingbird.o
 
 install: all
-	install -Dm755 "hummingbird.o" "/usr/bin/hummingbird"
-	install -Dm755 "shutdown.sh" "/usr/bin/shutdown"
-	install -Dm755 "reboot.sh" "/usr/bin/reboot"
+	install -Dm755 "hummingbird.o" "$(DESTDIR)/usr/bin/hummingbird"
+	install -Dm755 "shutdown.sh" "$(DESTDIR)/usr/bin/shutdown"
+	install -Dm755 "reboot.sh" "$(DESTDIR)/usr/bin/reboot"

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -19,7 +19,7 @@ _mount /dev/shm tmpfs shm=mode=1777,nosuid,nodev
 mount -o remount,rw /
 swapon -a
 
-sysctl --system 2>&1 >/dev/null
+sysctl --system >/dev/null 2>&1
 
 if [ "$?" != "0" ]
 then

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -58,9 +58,7 @@ type -p agetty && getty=agetty
     for index in 1 2 3 4 5 6 7 8
     do
         while :; do
-            "$getty" "115200,38400,9600" \
-                     "tty${index}" \
-                     "linux"
+            "$getty" "115200,38400,9600" "tty${index}" "linux"
         done &
     done
 

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -19,14 +19,14 @@ _mount /dev/shm tmpfs shm=mode=1777,nosuid,nodev
 mount -o remount,rw /
 swapon -a
 
-sysctl --system 2>1 >/dev/null
+sysctl --system 2>&1 >/dev/null
 
 if [ "$?" != "0" ]
 then
     # reimplement --system (try --system flag first because it's faster than this implementation)
-    
+
     control_files=""
-    
+
     directories="/etc /run /usr/local/lib /usr/lib /lib"
     for directory in $directories
     do
@@ -39,10 +39,10 @@ then
             done
         fi
     done
-    
+
     control_file_cache=$control_files
     control_files=""
-    
+
     for control_file in $control_file_cache
     do
         skip_file=0
@@ -53,7 +53,7 @@ then
                 skip_file=1
             fi
         done
-        
+
         if [ "$skip_file" = "0" ]
         then
             control_files="$control_files $control_file"
@@ -63,17 +63,17 @@ fi
 
 for control_file in $control_files
 do
-    sysctl -p $control_file 2>1 >/dev/null
+    sysctl -p $control_file >/dev/null 2>&1
     # some implementations don't allow for multiple files to pass through -p
 done
 
 if [ -f "/etc/sysctl.conf" ]
 then
-    sysctl -p /etc/sysctl.conf 2>1 >/dev/null
+    sysctl -p /etc/sysctl.conf >/dev/null 2>&1
 fi
 
 # TODO: fucking change this systemd dep already, just haven't gotten to it yet
-/lib/systemd/systemd-udevd --daemon &>/dev/null
+/lib/systemd/systemd-udevd --daemon >/dev/null 2>&1
 udevadm trigger --action=add --type=subsystems
 udevadm trigger --action=add --type=devices
 udevadm settle
@@ -95,7 +95,7 @@ do
                 eval "$command 115200,38400,9600 tty${index} linux"
             done)
         done
-    
+
         while :; do
             sleep 2147483648 # 2^31
         done

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -19,9 +19,7 @@ _mount /dev/shm tmpfs shm=mode=1777,nosuid,nodev
 mount -o remount,rw /
 swapon -a
 
-sysctl --system >/dev/null 2>&1
-
-if [ "$?" != "0" ]
+if sysctl --system >/dev/null 2>&1
 then
     # reimplement --system (try --system flag first because it's faster than this implementation)
 

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -51,21 +51,20 @@ then
     sh /etc/rc.local
 fi
 
-for command in agetty getty
-do
-    type "$command" >/dev/null 2>&1 && {
-        for index in 1 2 3 4 5 6 7 8
-        do
-            (while :; do
-                eval "$command 115200,38400,9600 tty${index} linux"
-            done)
-        done
+type -p getty  && getty=getty
+type -p agetty && getty=agetty
 
+[ -n "$getty" ] && {
+    for index in 1 2 3 4 5 6 7 8
+    do
         while :; do
-            sleep 2147483648 # 2^31
-        done
-        break
-    }
-done
+            "$getty" "115200,38400,9600" \
+                     "tty${index}" \
+                     "linux"
+        done &
+    done
+
+    wait
+}
 
 echo "No getty command found, dropping init"

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -19,56 +19,23 @@ _mount /dev/shm tmpfs shm=mode=1777,nosuid,nodev
 mount -o remount,rw /
 swapon -a
 
-if sysctl --system >/dev/null 2>&1
-then
-    # reimplement --system (try --system flag first because it's faster than this implementation)
+# 'sysctl --system' implementation using 'find'.
+find /run/sysctl.d \
+     /etc/sysctl.d \
+     /usr/local/lib/sysctl.d \
+     /usr/lib/sysctl.d \
+     /lib/sysctl.d \
+     /etc/sysctl.conf \
+     -name \*.conf -type f 2>/dev/null \
+| while read -r conf; do
+    seen="$seen ${conf##*/}"
 
-    control_files=""
-
-    directories="/etc /run /usr/local/lib /usr/lib /lib"
-    for directory in $directories
-    do
-        directory="$directory/sysctl.d"
-        if [ -d "$directory" ] && [ -n "$(ls directory)" ]
-        then
-            for file in $directory/*
-            do
-                control_files="$control_files $file"
-            done
-        fi
-    done
-
-    control_file_cache=$control_files
-    control_files=""
-
-    for control_file in $control_file_cache
-    do
-        skip_file=0
-        for file in $control_files
-        do
-            if [ "${control_file##*/}" = "${file##*/}" ]
-            then
-                skip_file=1
-            fi
-        done
-
-        if [ "$skip_file" = "0" ]
-        then
-            control_files="$control_files $control_file"
-        fi
-    done
-fi
-
-for control_file in $control_files
-do
-    sysctl -p $control_file >/dev/null 2>&1
-    # some implementations don't allow for multiple files to pass through -p
+    case $seen in
+        *" ${conf##*/} "*) ;;
+        *) echo "* Applying $conf ..."
+           sysctl -p "$conf" ;;
+    esac
 done
-
-if [ -f "/etc/sysctl.conf" ]
-then
-    sysctl -p /etc/sysctl.conf >/dev/null 2>&1
-fi
 
 # TODO: fucking change this systemd dep already, just haven't gotten to it yet
 /lib/systemd/systemd-udevd --daemon >/dev/null 2>&1

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -46,7 +46,7 @@ then
         skip_file=0
         for file in $control_files
         do
-            if [ "$(basename $control_file)" = "$(basename $file)" ]
+            if [ "${control_file##*/}" = "${file##*/}" ]
             then
                 skip_file=1
             fi

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -46,10 +46,7 @@ udevadm settle
 cat /etc/hostname >| /proc/sys/kernel/hostname
 ip link set up dev lo
 
-if [ -f "/etc/rc.local" ]
-then
-    sh /etc/rc.local
-fi
+[ -f /etc/rc.local ] && sh /etc/rc.local
 
 type -p getty  && getty=getty
 type -p agetty && getty=agetty

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -86,7 +86,7 @@ fi
 
 for command in agetty getty
 do
-    [ "$(command -v $command)" ] && {
+    type "$command" >/dev/null 2>&1 && {
         for index in 1 2 3 4 5 6 7 8
         do
             (while :; do

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -97,7 +97,7 @@ do
         while :; do
             sleep 2147483648 # 2^31
         done
-        break;
+        break
     }
 done
 

--- a/etc/rc.shutdown
+++ b/etc/rc.shutdown
@@ -1,9 +1,7 @@
 #!/bin/sh
 
-if [ -f "/etc/rc.shutdown.local" ]
-then
+[ -f /etc/rc.shutdown.local ] &&
     sh /etc/rc.shutdown.local
-fi
 
 rm -rf /tmp/* /var/tmp/*
 sync


### PR DESCRIPTION
This allows package managers (`xbps-src`, `makepkg`, `puke`) to install `hummingbird` to a "fake" root. It also allows for installing to a chroot.

Example:

```sh
make DESTDIR=~/.chroot install
```

The result is `~/.chroot/usr/bin/hummingbird` etc.