### PR TITLE
rc.init: Minor fixes

### DIFF
--- a/etc/rc.init
+++ b/etc/rc.init
@@ -46,14 +46,13 @@ udevadm settle
 cat /etc/hostname >| /proc/sys/kernel/hostname
 ip link set up dev lo
 
-[ -f /etc/rc.local ] && sh /etc/rc.local
+[ -f /etc/rc.local ] && . /etc/rc.local
 
 type -p getty  && getty=getty
 type -p agetty && getty=agetty
 
 [ -n "$getty" ] && {
-    for index in 1 2 3 4 5 6 7 8
-    do
+    for index in 1 2 3 4 5 6 7 8; do
         while :; do
             "$getty" "115200,38400,9600" "tty${index}" "linux"
         done &


### PR DESCRIPTION
- Source the `rc.local` file.
    - `sh` will use `PATH` and may not point to `/bin/sh`.
- One cosmetic fix.
    - Matches the other `do`.