### PR TITLE
rc.init: fixed slow loading during setup_random

### DIFF
--- a/etc/rc.init
+++ b/etc/rc.init
@@ -90,7 +90,7 @@ setup_random() {
         cat /tmp/random.seed > /dev/urandom
         rm /tmp/random.seed
     else
-        dd count=1 bs=512 if=/dev/random of=/dev/urandom
+        dd count=1 bs=512 if=/dev/urandom of=/tmp/random.seed
     fi
 }
 

--- a/etc/rc.init
+++ b/etc/rc.init
@@ -87,10 +87,9 @@ setup_hostname() {
 
 setup_random() {
     if [ -f /tmp/random.seed ]; then
-        cat /tmp/random.seed > /dev/urandom
-        rm /tmp/random.seed
+        cat /var/random.seed > /dev/urandom
     else
-        dd count=1 bs=512 if=/dev/urandom of=/tmp/random.seed
+        dd count=1 bs=512 if=/dev/random of=/var/random.seed
     fi
 }
 

--- a/etc/rc.shutdown
+++ b/etc/rc.shutdown
@@ -4,7 +4,7 @@
     . /etc/rc.shutdown.local
 
 rm -rf /tmp/* /var/tmp/*
-dd count=1 bs=512 if=/dev/urandom of=/tmp/random.seed
+dd count=1 bs=512 if=/dev/random of=/var/random.seed
 sync
 swapoff -a
 umount -a -r

--- a/etc/rc.shutdown
+++ b/etc/rc.shutdown
@@ -4,7 +4,7 @@
     . /etc/rc.shutdown.local
 
 rm -rf /tmp/* /var/tmp/*
-dd count=1 bs=512 if=/dev/random of=/tmp/random.seed
+dd count=1 bs=512 if=/dev/urandom of=/tmp/random.seed
 sync
 swapoff -a
 umount -a -r


### PR DESCRIPTION
`/dev/random` generates PRNGs slower than `/dev/urandom` which is suspected to slow down the `setup_random` function during boot

Taken from:
https://git.2f30.org/ports/file/fs/bin/rc.init.html#l86
https://git.2f30.org/ports/file/fs/bin/rc.shutdown.html#l43