### PR TITLE
Source scripts in /etc/rc.d and /etc/hummingbird.d at interlude and shutdown. (dist/kiss)

### DIFF
--- a/dist/kiss/interlude
+++ b/dist/kiss/interlude
@@ -40,6 +40,6 @@ setup_sysctl
 
 ip link set up dev lo
 
-for file in /etc/hummingbird.d/*.boot; do
+for file in /etc/hummingbird.d/*.boot /etc/rc.d/*.boot; do
     [ -f "$file" ] && . "$file"
 done

--- a/dist/kiss/shutdown
+++ b/dist/kiss/shutdown
@@ -2,7 +2,7 @@
 
 . /usr/lib/hummingbird/rc.lib
 
-for file in /etc/rc.d/*.pre.shutdown; do
+for file in /etc/hummingbird.d/*.pre.shutdown /etc/rc.d/*.pre.shutdown; do
     [ -f "$file" ] && . "$file"
 done
 


### PR DESCRIPTION
For now, scripts that match `/etc/rc.d/*.pre.shutdown` are sourced at shutdown, but at interlude, it's those that match `/etc/hummingbird.d/*.boot`. That doesn't sound right. This commit makes them sourced from both location at both moments.