### PR TITLE
Improve signals handling

### DIFF
--- a/src/hummingbird.c
+++ b/src/hummingbird.c
@@ -19,8 +19,11 @@ void execute(char *path) {
 
     if (pid == 0)
         execv(path, command);
-    else if (pid)
-        do { errno = 0; waitpid(pid, NULL, 0); } while (errno == EINTR);
+    else if (pid) {
+        do {
+            waitpid(pid, NULL, 0);
+        } while (errno == EINTR);
+    }
 }
 
 int main(int argc, char **argv) {

--- a/src/hummingbird.c
+++ b/src/hummingbird.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <errno.h>
 #include <sys/wait.h>
 
 #include "hummingbird.h"
@@ -19,7 +20,7 @@ void execute(char *path) {
     if (pid == 0)
         execv(path, command);
     else if (pid)
-        waitpid(pid, NULL, 0);
+        do { errno = 0; waitpid(pid, NULL, 0); } while (errno == EINTR);
 }
 
 int main(int argc, char **argv) {

--- a/src/signal.c
+++ b/src/signal.c
@@ -46,6 +46,6 @@ int poweroff_machine() {
 }
 
 int reap_children() {
-    waitpid(-1, NULL, WNOHANG);
+    while(waitpid(-1, NULL, WNOHANG) > 0);
     return -1;
 }


### PR DESCRIPTION
**Do not let unexpected signals trigger emergency shells** (hummingbird.c): the `waitpid` call isn't guarded against EINTR errors. I believe this can fix #24 as I had similar symptoms when trying to use s6-rc (which double forks lots of processes during startup, sending a barrage of SIGCHLDs to PID 1). In between the "Service started" messages, the "Init failed, starting emergency shell..." message appeared, and a few seconds later the shutdown procedure began by itself (without me typing Ctrl+D or `exit`). This is consistent with the `waitpid` in `execute()` returning earlier than expected.

**Reap as many children as possible per SIGCHLD** (signal.c): After applying the above fix and booting successfully, had zombie processes laying around. Apparently the correct behavior is to reap as many zombies as possible per SIGCHLD as one signal might come with a batch of multiple reparented processes. TODO: ensure `execute()` will always reap the runlevel script (maybe a global variable?).

Tested on Gentoo with a tty script that spawns a s6-rc supervision tree.
